### PR TITLE
修复了 sso 单点登录的相关错误

### DIFF
--- a/user/sso/sso.php
+++ b/user/sso/sso.php
@@ -5,7 +5,7 @@ if (!defined('IN_DZZ')) {
 }
 global  $_G;
 
-$oauth = new user\sso\classes\Oauth();
+$oauth = new user\sso\classes\oauth();// fix Oauth
 
 $do = isset($_GET['do']) ? $_GET['do']:'';
 


### PR DESCRIPTION
参考的修复标准是 http://work.jintengwangluo.com/index.php?mod=corpus&op=list&cid=2#fid_145

1、按照文档中的地址 修改 index.php 为 sso.php
2、修改 oauth 类的首字母大小写 解决了 linux 下找不到对应类的问题