### PR TITLE
修复参考了官方文档中关于 sso 单点登录的章节

### DIFF
--- a/user/sso/sso.php
+++ b/user/sso/sso.php
@@ -5,7 +5,7 @@ if (!defined('IN_DZZ')) {
 }
 global  $_G;
 
-$oauth = new user\sso\classes\Oauth();
+$oauth = new user\sso\classes\oauth();
 
 $do = isset($_GET['do']) ? $_GET['do']:'';
 


### PR DESCRIPTION
版本所有的修复依据目前官方的文档进行 http://www.dzzoffice.com/corpus/list?cid=1#fid_117

修复了两个问题
当前版本按照文档中请求 index.php?mod=sso&op=oauth&do=getkeyid&bakcurl=回调地址
会报错 user/sso.php 不存在 解决方案是修改了 文件名

另外一个问题是当前版本在 centos 上请求会报错 原因是 oauth 的首字母大小写
解决方案是 修改文件中的首字母为小写