### PR TITLE
input-label样式更正

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -885,7 +885,7 @@ dl>dd{
 	transition: top 0.2s;
 	-webkit-transition: top 0.2s;
 	-o-transition: top 0.2s;
-	position: absolute;
+	/* position: absolute; */
 	left: 0;
 	line-height: 30px;
 	margin: 0;


### PR DESCRIPTION
问题出现位置：【系统设置】【编辑文件夹权限】，input-label与输入框重叠