### PR TITLE
Prevent permission bypass via absent permfilter in filelist operation

### DIFF
--- a/dzz/system/fileselection/explorerfile.php
+++ b/dzz/system/fileselection/explorerfile.php
@@ -23,7 +23,7 @@ if ($operation == 'filelist') {
     $bz = empty($_GET['bz']) ? '' : urldecode($_GET['bz']);
     $marker = empty($_GET['marker']) ? '' : trim($_GET['marker']);
     $data = array();
-    $permfilter = isset($_GET['permfilter']) ? trim($_GET['permfilter']) : 'read';
+    $permfilter = isset($_GET['permfilter']) ? trim($_GET['permfilter']) : 'read1,read2';
     if ($bz) {//云盘查询
         $asc = intval($_GET['asc']);
         list($prex, $id) = explode('-', $sid);

--- a/dzz/system/fileselection/explorerfile.php
+++ b/dzz/system/fileselection/explorerfile.php
@@ -23,7 +23,7 @@ if ($operation == 'filelist') {
     $bz = empty($_GET['bz']) ? '' : urldecode($_GET['bz']);
     $marker = empty($_GET['marker']) ? '' : trim($_GET['marker']);
     $data = array();
-    $permfilter = isset($_GET['permfilter']) ? trim($_GET['permfilter']) : '';
+    $permfilter = isset($_GET['permfilter']) ? trim($_GET['permfilter']) : 'read';
     if ($bz) {//云盘查询
         $asc = intval($_GET['asc']);
         list($prex, $id) = explode('-', $sid);


### PR DESCRIPTION
**Summary**
This patch addresses a logic flaw in the file listing operation where permission filtering is bypassed if the permfilter parameter is missing from the request.

**Details**
The following condition is never reached unless permfilter is explicitly provided:

```
if ($v['type'] != 'folder' && $permfilter && $v['gid']) {
    if (filter_permdata($permfilter, $folder['perm'], $v, $uid)) {
        continue;
    }
}
```

As a result, a user can retrieve files and folders across the system without permission checks simply by omitting the permfilter parameter:

`index.php?mod=system&op=fileselection&do=explorerfile&operation=filelist&sid=f-`

**Impact**
This allows unauthorized listing of files and folders belonging to other users, violating access control expectations.

**Fix**
The patch sets a default permfilter = 'read1,read2', ensuring filter_permdata() is always triggered.

**Note**
I haven't audited all files in depth, but [fileselection.php](https://github.com/notagain-pwn/dzzoffice/blob/master/dzz/system/fileselection.php)  appears to lack strict permission checks if called with type=1.

The permission logic there might rely on client input (perm) without strict server-side validation.