### PR TITLE
修复回收站与进程删除的 SQL 双重转义

### DIFF
--- a/core/class/table/table_process.php
+++ b/core/class/table/table_process.php
@@ -21,9 +21,10 @@ class table_process extends dzz_table {
     }
 
     public function delete_process($name, $time) {
-        $name = addslashes($name);
-        return DB::delete('process', "processid='" . daddslashes($name) . "' OR expiry<" . intval($time));
+        return DB::delete('process', [
+            'where' => 'processid=%s OR expiry<%d',
+            'arg' => [$name, $time],
+        ]);
     }
 }
-
 

--- a/core/class/table/table_resources_recyle.php
+++ b/core/class/table/table_resources_recyle.php
@@ -256,14 +256,14 @@ class table_resources_recyle extends dzz_table {
     }
 
     public function delete_by_rid($rid) {
-        if (!is_array($rid)) $rid = (array)$rid;
-        $rids = '';
-        foreach ($rid as $v) {
-            $rids .= "'" . $v . "',";
+        if (!is_array($rid)) {
+            $rid = (array)$rid;
         }
-        $rids = substr($rids, 0, -1);
-        DB::delete($this->_table, "rid in (" . daddslashes($rids) . ")");
-        return true;
+
+        return DB::delete($this->_table, [
+            'where' => 'rid IN (%n)',
+            'arg' => [$rid],
+        ]);
     }
 
     //彻底删除


### PR DESCRIPTION
## 问题

回收站彻底删除会先手工拼接带引号的 RID 列表，再将整段 SQL 片段传给 `daddslashes()`，导致 MariaDB 收到 `\'...` 并报 SQL 语法错误。

`table_process::delete_process()` 也会先 `addslashes()` 再由数据库层转义，使包含引号或反斜杠的进程名无法被正确删除。

## 修复

- 回收站删除改用数据库层的 `%n` 列表占位符。
- 进程删除改用 `%s` 和 `%d` 参数化占位符。

## 验证

- Docker Compose：DzzOffice PHP 镜像 + MariaDB 12.3.2。
- 验证多个 RID 可彻底删除；包含引号和反斜杠的进程记录可删除。
- 两个修改后的 PHP 文件均通过 `php -l`。

## 范围

本 PR 仅包含两处生产 PHP 源码修复；本地验证脚本与 Compose 配置未提交。