### PR TITLE
修复应用市场断点下载未使用 HTTP Range 导致大文件极慢的问题

### DIFF
--- a/core/class/filesock/filesock_stream.php
+++ b/core/class/filesock/filesock_stream.php
@@ -17,6 +17,9 @@ class filesock_stream extends filesock_base {
 		$headerlist['User-Agent'] = $this->useragent;
 		$headerlist['Host'] = $this->host.':'.$this->port;
 		$headerlist['Connection'] = 'Close';
+		if($this->position && $this->limit) {
+			$headerlist['Range'] = 'bytes='.$this->position.'-'.($this->position + $this->limit - 1);
+		}
 		if($this->method == 'POST') {
 			if($this->encodetype == 'application/x-www-form-urlencoded') {
 				$data = http_build_query($this->post);
@@ -146,7 +149,8 @@ class filesock_stream extends filesock_base {
 				}
 				$GLOBALS['filesockheader'] = $this->filesockheader = $headers;
 	
-				if($this->position) {
+				$israngedresponse = $this->position && preg_match('/^HTTP\/\S+\s+206\b/m', $headers);
+				if($this->position && !$israngedresponse) {
 					for($i=0; $i<$this->position; $i++) {
 						fgetc($fp);
 					}


### PR DESCRIPTION
修复应用市场下载大型应用包时，续传分块未使用 HTTP Range 请求的问题。

此前每个 1 MiB 分块都会从远端文件开头重新读取，再逐字节跳过已下载内容，下载越靠后越慢。

本次修改在续传时发送标准 Range 请求，并在服务端返回 206 Partial Content 时直接使用响应内容；若远端服务不支持 Range，则保留原有跳过逻辑作为兼容回退。

已验证市场中的 drawio 大型应用包下载可保持稳定速度。